### PR TITLE
credentials: retry 500/502 response

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -62,6 +62,8 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
     and Access Management (IAM) system
     """
 
+    RETRY_CODES = frozenset([413, 429, 500, 502, 503])
+
     def __init__(
         self,
         username=None,
@@ -77,7 +79,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
             total=5,
             backoff_factor=0.5,
             raise_on_status=False,
-            status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,
+            status_forcelist=self.RETRY_CODES,
         )
         self.__openid_conf = None
         self.__jwks = None
@@ -128,7 +130,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
                 backoff_factor=0.5,
                 allowed_methods=None,
                 raise_on_status=False,
-                status_forcelist=Retry.RETRY_AFTER_STATUS_CODES,
+                status_forcelist=self.RETRY_CODES,
             ),
             proxies=self.__proxies,
         )


### PR DESCRIPTION
The website will frequently respond
500/502, so back off and try again when
that happens.