### PR TITLE
query: re-use session/retry logic from credentials

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -67,6 +67,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
     A class for handling credentials for the Copernicus Identity
     and Access Management (IAM) system
     """
+
     RETRY_CODES = frozenset([413, 429, 500, 502, 503])
 
     RETRIES = Retry(
@@ -213,8 +214,11 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
         if self.__openid_conf:
             return self.__openid_conf
 
-        session = self.__make_session(
-            authorization=False, max_retries=self.__retries, proxies=self.__proxies
+        session = self.make_session(
+            caller=self,
+            authorization=False,
+            max_retries=self.RETRIES,
+            proxies=self.__proxies,
         )
         response = session.get(self.__openid_configuration_endpoint, timeout=120)
         response.raise_for_status()


### PR DESCRIPTION
The Copernicus web site sometimes responds 500 (along other error codes) to queries. Use the retry logic from credentials so queries are retried just like downloads.

This PR creates a merge conflict with #120 so one has to be merged before the other, but the changes are complementary.