### PR TITLE
credentials: force initial token refresh

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -89,8 +89,8 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
 
         self.__access_token = None
         self.__refresh_token = None
-        self.__access_token_expires = datetime.now()
-        self.__refresh_token_expires = datetime.now()
+        self.__access_token_expires = datetime.now() - timedelta(hours=8)
+        self.__refresh_token_expires = self.__access_token_expires
 
         self.__lock = threading.Lock()
 


### PR DESCRIPTION
Windows/Python 3.12 can get to the check
in __ensure_tokens without having any
time passed. Set an initial time that
is in the past to force a token
refresh on creation.

Fixes #117