### PR TITLE
logger: add missing method

### DIFF
--- a/src/cdsetool/logger.py
+++ b/src/cdsetool/logger.py
@@ -15,6 +15,11 @@ class NoopLogger:
         Log a debug message.
         """
 
+    def error(self, *kwargs):
+        """
+        Log an error message.
+        """
+
     def info(self, *kwargs):
         """
         Log an info message.


### PR DESCRIPTION
The code uses the error method now, so add that to the logger object.
