### PR TITLE
Add type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,17 @@ max-locals = 20
 max-line-length = "88"
 disable="fixme"
 
+[tool.pyright]
+exclude = ["**/__pycache__", ".venv"]
+
+# Can be strict too, see more fine-grained settings at:
+# https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults
+typeCheckingMode = "standard"
+
+executionEnvironments = [
+  { root = "./" }
+]
+
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",

--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -5,7 +5,7 @@ Command line interface
 import os
 import sys
 import json as JSON
-from typing import List, Optional
+from typing import Dict, List, Optional
 from typing_extensions import Annotated
 import typer
 from cdsetool.query import describe_collection, query_features
@@ -19,7 +19,7 @@ app.add_typer(query_app, name="query")
 
 
 @query_app.command("search-terms")
-def query_search_terms(collection: str):
+def query_search_terms(collection: str) -> None:
     """
     List the available search terms for a collection
     """
@@ -51,13 +51,12 @@ def query_search(
         ),
     ] = None,
     json: Annotated[bool, typer.Option(help="Output JSON")] = False,
-):
+) -> None:
     """
     Search for features matching the search terms
     """
     search_term = search_term or []
-    search_term = _to_dict(search_term)
-    features = query_features(collection, search_term)
+    features = query_features(collection, _to_dict(search_term))
 
     for feature in features:
         if json:
@@ -84,7 +83,7 @@ def download(
             + "Pass multiple times for multiple search terms"
         ),
     ] = None,
-):
+) -> None:
     """
     Download all features matching the search terms
     """
@@ -93,8 +92,7 @@ def download(
         sys.exit(1)
 
     search_term = search_term or []
-    search_term = _to_dict(search_term)
-    features = query_features(collection, search_term)
+    features = query_features(collection, _to_dict(search_term))
 
     list(
         download_features(
@@ -116,7 +114,7 @@ def main():
     app()
 
 
-def _to_dict(term_list: List[str]):
+def _to_dict(term_list: List[str]) -> Dict[str, str]:
     search_terms = {}
     for item in term_list:
         key, value = item.split("=")

--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -6,6 +6,8 @@ the Copernicus Identity and Access Management (IAM) system.
 from datetime import datetime, timedelta
 import netrc
 import threading
+from typing import Any, Dict, List, Union
+
 import requests
 import jwt
 from requests.adapters import HTTPAdapter
@@ -79,27 +81,27 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
 
     def __init__(
         self,
-        username=None,
-        password=None,
-        openid_configuration_endpoint=None,
-        proxies=None,
-    ):
-        self.__username = username
-        self.__password = password
+        username: Union[str, None] = None,
+        password: Union[str, None] = None,
+        openid_configuration_endpoint: Union[str, None] = None,
+        proxies: Union[Dict[str, str], None] = None,
+    ) -> None:
+        self.__username: Union[str, None] = username
+        self.__password: Union[str, None] = password
 
-        self.__proxies = proxies
+        self.__proxies: Union[Dict[str, str], None] = proxies
         self.__openid_conf = None
         self.__jwks = None
-        self.__openid_configuration_endpoint = (
+        self.__openid_configuration_endpoint: str = (
             openid_configuration_endpoint
             or "https://identity.dataspace.copernicus.eu"
             + "/auth/realms/CDSE/.well-known/openid-configuration"
         )
 
-        self.__access_token = None
-        self.__refresh_token = None
-        self.__access_token_expires = datetime.now() - timedelta(hours=8)
-        self.__refresh_token_expires = self.__access_token_expires
+        self.__access_token: Union[str, None] = None
+        self.__refresh_token: Union[str, None] = None
+        self.__access_token_expires: datetime = datetime.now() - timedelta(hours=8)
+        self.__refresh_token_expires: datetime = self.__access_token_expires
 
         self.__lock = threading.Lock()
 
@@ -108,14 +110,19 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
 
         self.__ensure_tokens()
 
-    def get_session(self):
+    def get_session(self) -> requests.Session:
         """
         Returns a session with the credentials set as the Authorization header
         """
         return self.make_session(self, True, self.RETRIES, self.__proxies)
 
     @staticmethod
-    def make_session(caller, authorization, max_retries, proxies):
+    def make_session(
+        caller,
+        authorization: bool,
+        max_retries: Retry,
+        proxies: Union[Dict[str, str], None],
+    ) -> requests.Session:
         """
         Creates a new session. Authorization is only available from callers
         that are subclasses of Credentials.
@@ -133,7 +140,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
             session.headers.update({"Authorization": f"Bearer {token}"})
         return session
 
-    def __token_exchange(self, data):
+    def __token_exchange(self, data: Dict[str, str]) -> timedelta:
         # Make a session that will retry post, respecting the retry-after
         # header when we get a 503 and a few other temporary failures.
         session = self.make_session(
@@ -154,7 +161,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
             raise InvalidCredentialsException(
                 "Unable to exchange token with "
                 + f"username: {self.__username} and "
-                + f"password: {len(self.__password) * '*'}"
+                + f"password: {len(self.__password or '') * '*'}"
             )
 
         if response.status_code != 200:
@@ -166,7 +173,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
         self.__refresh_token = response["refresh_token"]
         return timedelta(seconds=response["refresh_expires_in"])
 
-    def __ensure_tokens(self):
+    def __ensure_tokens(self) -> None:
         with self.__lock:
             refresh_expire_delta = None
             if self.__access_token_expires < datetime.now():
@@ -184,6 +191,10 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
                         "client_id": "cdse-public",
                     }
                 refresh_expire_delta = self.__token_exchange(data)
+            if not self.__access_token:
+                raise InvalidCredentialsException(
+                    "Internal error: access token not available"
+                )
             try:
                 key = self.__jwk_client.get_signing_key_from_jwt(self.__access_token)
             except jwt.PyJWKClientConnectionError as e:
@@ -203,16 +214,15 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
                     datetime.fromtimestamp(data["iat"]) + refresh_expire_delta
                 )
 
-    def __read_credentials(self):
-        try:
-            self.__username, _, self.__password = netrc.netrc().authenticators(
-                self.__token_endpoint
-            )
-        except Exception as exc:
-            raise NoCredentialsException("No credentials found") from exc
+    def __read_credentials(self) -> None:
+        rv = netrc.netrc().authenticators(self.__token_endpoint)
+        if isinstance(rv, tuple):
+            self.__username, _, self.__password = rv
+        else:
+            raise NoCredentialsException("No credentials found")
 
     @property
-    def __openid_configuration(self):
+    def __openid_configuration(self) -> Dict[str, Any]:
         if self.__openid_conf:
             return self.__openid_conf
 
@@ -228,19 +238,19 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
         return self.__openid_conf
 
     @property
-    def __token_endpoint(self):
+    def __token_endpoint(self) -> str:
         return self.__openid_configuration["token_endpoint"]
 
     @property
-    def __jwks_uri(self):
+    def __jwks_uri(self) -> str:
         return self.__openid_configuration["jwks_uri"]
 
     @property
-    def __id_token_signing_algos(self):
+    def __id_token_signing_algos(self) -> List[str]:
         return self.__openid_configuration["id_token_signing_alg_values_supported"]
 
     @property
-    def __jwk_client(self):
+    def __jwk_client(self) -> jwt.PyJWKClient:
         if self.__jwks:
             return self.__jwks
 
@@ -249,7 +259,9 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
         return self.__jwks
 
 
-def validate_credentials(username=None, password=None):
+def validate_credentials(
+    username: Union[str, None] = None, password: Union[str, None] = None
+) -> bool:
     """
     This function validates CDSE credentials and returns a bool.
     If credentials are none, .netrc will be validated

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -4,6 +4,7 @@ Query the Copernicus Data Space Ecosystem OpenSearch API
 https://documentation.dataspace.copernicus.eu/APIs/OpenSearch.html
 """
 
+from typing import Any, Dict, Union
 from xml.etree import ElementTree
 from datetime import datetime, date
 import re
@@ -13,11 +14,11 @@ from cdsetool.credentials import Credentials
 
 
 class _FeatureIterator:
-    def __init__(self, feature_query):
+    def __init__(self, feature_query) -> None:
         self.index = 0
         self.feature_query = feature_query
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.feature_query)
 
     def __iter__(self):
@@ -40,9 +41,14 @@ class FeatureQuery:
     Queries the next batch when the current batch is exhausted.
     """
 
-    total_results = None
+    total_results: int = -1
 
-    def __init__(self, collection, search_terms, proxies=None):
+    def __init__(
+        self,
+        collection: str,
+        search_terms: Dict[str, Any],
+        proxies: Union[Dict[str, str], None] = None,
+    ) -> None:
         self.features = []
         self.proxies = proxies
         self.next_url = _query_url(
@@ -52,8 +58,8 @@ class FeatureQuery:
     def __iter__(self):
         return _FeatureIterator(self)
 
-    def __len__(self):
-        if self.total_results is None:
+    def __len__(self) -> int:
+        if self.total_results < 0:
             self.__fetch_features()
 
         return self.total_results
@@ -64,7 +70,7 @@ class FeatureQuery:
 
         return self.features[index]
 
-    def __fetch_features(self):
+    def __fetch_features(self) -> None:
         if self.next_url is None:
             return
         session = Credentials.make_session(
@@ -81,7 +87,7 @@ class FeatureQuery:
 
             self.__set_next_url(res)
 
-    def __set_next_url(self, res):
+    def __set_next_url(self, res) -> None:
         links = res.get("properties", {}).get("links") or []
         self.next_url = next(
             (link for link in links if link.get("rel") == "next"), {}
@@ -91,14 +97,18 @@ class FeatureQuery:
             self.next_url = self.next_url.replace("exactCount=1", "exactCount=0")
 
 
-def query_features(collection, search_terms, proxies=None):
+def query_features(
+    collection: str,
+    search_terms: Dict[str, Any],
+    proxies: Union[Dict[str, str], None] = None,
+) -> FeatureQuery:
     """
     Returns an iterator over the features matching the search terms
     """
     return FeatureQuery(collection, {"maxRecords": 2000, **search_terms}, proxies)
 
 
-def shape_to_wkt(shape):
+def shape_to_wkt(shape: str) -> str:
     """
     Convert a shapefile to a WKT string
     """
@@ -110,12 +120,11 @@ def shape_to_wkt(shape):
     )
 
 
-def geojson_to_wkt(geojson):
+def geojson_to_wkt(geojson_in: Union[str, Dict]) -> str:
     """
     Convert a geojson geometry to a WKT string
     """
-    if isinstance(geojson, str):
-        geojson = json.loads(geojson)
+    geojson = json.loads(geojson_in) if isinstance(geojson_in, str) else geojson_in
 
     if geojson.get("type") == "Feature":
         geojson = geojson["geometry"]
@@ -134,7 +143,9 @@ def geojson_to_wkt(geojson):
     return f"POLYGON({paired_coord})"
 
 
-def describe_collection(collection, proxies=None):
+def describe_collection(
+    collection: str, proxies: Union[Dict[str, str], None] = None
+) -> Dict[str, Any]:
     """
     Get a list of valid options for a given collection in key value pairs
     """
@@ -163,7 +174,11 @@ def describe_collection(collection, proxies=None):
     return parameters
 
 
-def _query_url(collection, search_terms, proxies=None):
+def _query_url(
+    collection: str,
+    search_terms: Dict[str, Any],
+    proxies: Union[Dict[str, str], None] = None,
+) -> str:
     description = describe_collection(collection, proxies=proxies)
 
     query_list = []
@@ -178,7 +193,7 @@ def _query_url(collection, search_terms, proxies=None):
     )
 
 
-def _serialize_search_term(search_term):
+def _serialize_search_term(search_term: Any) -> str:
     if isinstance(search_term, list):
         return ",".join(search_term)
 
@@ -191,14 +206,14 @@ def _serialize_search_term(search_term):
     return str(search_term)
 
 
-def _validate_search_term(key, search_term, description):
+def _validate_search_term(key: str, search_term: str, description) -> None:
     _assert_valid_key(key, description)
     _assert_match_pattern(search_term, description.get(key).get("pattern"))
     _assert_min_inclusive(search_term, description.get(key).get("minInclusive"))
     _assert_max_inclusive(search_term, description.get(key).get("maxInclusive"))
 
 
-def _assert_valid_key(key, description):
+def _assert_valid_key(key: str, description: Dict[str, Any]) -> None:
     assert key in description.keys(), (
         f'search_term with name "{key}" '
         + "was not found for collection."
@@ -206,7 +221,7 @@ def _assert_valid_key(key, description):
     )
 
 
-def _assert_match_pattern(search_term, pattern):
+def _assert_match_pattern(search_term: str, pattern: Union[str, None]) -> None:
     if not pattern:
         return
 
@@ -215,7 +230,7 @@ def _assert_match_pattern(search_term, pattern):
     ), f"search_term {search_term} does not match pattern {pattern}"
 
 
-def _assert_min_inclusive(search_term, min_inclusive):
+def _assert_min_inclusive(search_term: str, min_inclusive: Union[str, None]) -> None:
     if not min_inclusive:
         return
 
@@ -224,7 +239,7 @@ def _assert_min_inclusive(search_term, min_inclusive):
     ), f"search_term {search_term} is less than min_inclusive {min_inclusive}"
 
 
-def _assert_max_inclusive(search_term, max_inclusive):
+def _assert_max_inclusive(search_term: str, max_inclusive: Union[str, None]) -> None:
     if not max_inclusive:
         return
 
@@ -233,12 +248,15 @@ def _assert_max_inclusive(search_term, max_inclusive):
     ), f"search_term {search_term} is greater than max_inclusive {max_inclusive}"
 
 
-_describe_docs = {}
+_describe_docs: Dict[str, bytes] = {}
 
 
-def _get_describe_doc(collection, proxies=None):
-    if _describe_docs.get(collection):
-        return _describe_docs.get(collection)
+def _get_describe_doc(
+    collection: str, proxies: Union[Dict[str, str], None] = None
+) -> bytes:
+    docs = _describe_docs.get(collection)
+    if docs:
+        return docs
     session = Credentials.make_session(None, False, Credentials.RETRIES, proxies)
     with session.get(
         "https://catalogue.dataspace.copernicus.eu"
@@ -252,4 +270,4 @@ def _get_describe_doc(collection, proxies=None):
         )
 
         _describe_docs[collection] = res.content
-    return _describe_docs.get(collection)
+        return res.content

--- a/tests/credentials/credentials_test.py
+++ b/tests/credentials/credentials_test.py
@@ -1,3 +1,5 @@
+# pyright: reportAttributeAccessIssue=false
+
 import json
 import pytest
 import requests
@@ -16,7 +18,7 @@ from cdsetool.credentials import (
 )
 
 
-def _mock_openid(requests_mock):
+def _mock_openid(requests_mock) -> None:
     with open("tests/credentials/mock/openid-configuration.json") as f:
         requests_mock.get(
             "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/.well-known/openid-configuration",
@@ -24,7 +26,7 @@ def _mock_openid(requests_mock):
         )
 
 
-def _mock_token(requests_mock):
+def _mock_token(requests_mock) -> None:
     headers = {"alg": "RS256", "typ": "JWT", "kid": "key-9000"}
     now = datetime.datetime.now()
     payload = {
@@ -98,7 +100,7 @@ def _mock_token(requests_mock):
     )
 
 
-def _mock_jwks(mocker):
+def _mock_jwks(mocker) -> None:
     class MockResponse:
         def __init__(self, json_data):
             self.json_data = json_data
@@ -136,7 +138,7 @@ def _mock_jwks(mocker):
     mocker.patch("urllib.request.urlopen", return_value=MockResponse(jwks))
 
 
-def test_ensure_tokens(requests_mock, mocker):
+def test_ensure_tokens(requests_mock, mocker) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -162,7 +164,7 @@ def test_ensure_tokens(requests_mock, mocker):
     assert spy.call_count == 2
 
 
-def test_read_credentials(requests_mock, mocker):
+def test_read_credentials(requests_mock, mocker) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -184,7 +186,7 @@ def test_read_credentials(requests_mock, mocker):
         credentials = Credentials()
 
 
-def test_refresh_token(requests_mock, mocker):
+def test_refresh_token(requests_mock, mocker) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -205,7 +207,7 @@ def test_refresh_token(requests_mock, mocker):
     assert prev_access_token != credentials._Credentials__access_token
 
 
-def test_get_session(requests_mock, mocker):
+def test_get_session(requests_mock, mocker) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -220,7 +222,7 @@ def test_get_session(requests_mock, mocker):
     )
 
 
-def test_token_exchange(requests_mock, mocker):
+def test_token_exchange(requests_mock, mocker) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)

--- a/tests/logger/logger_test.py
+++ b/tests/logger/logger_test.py
@@ -5,7 +5,7 @@ from cdsetool.logger import NoopLogger
 from cdsetool.download import download_feature
 
 
-def test_noop_logger_is_default():
+def test_noop_logger_is_default() -> None:
     NoopLogger.debug = MagicMock()
 
     assert NoopLogger.debug.call_count == 0
@@ -24,7 +24,7 @@ def test_noop_logger_is_default():
     assert NoopLogger.debug.call_count == 1
 
 
-def test_noop_does_not_error():
+def test_noop_does_not_error() -> None:
     try:
         download_feature(
             {

--- a/tests/query/query_features_test.py
+++ b/tests/query/query_features_test.py
@@ -40,13 +40,13 @@ def _mock_sentinel_1(requests_mock):
             requests_mock.get(url, text=file.read())
 
 
-def test_query_features(requests_mock):
+def test_query_features(requests_mock) -> None:
     _mock_describe(requests_mock)
 
     assert type(query_features("Sentinel1", {"maxRecords": 10})) is FeatureQuery
 
 
-def test_query_features_length(requests_mock):
+def test_query_features_length(requests_mock) -> None:
     _mock_describe(requests_mock)
     _mock_sentinel_1(requests_mock)
 
@@ -61,7 +61,7 @@ def test_query_features_length(requests_mock):
     assert manual_count == 48
 
 
-def test_query_features_reusable(requests_mock):
+def test_query_features_reusable(requests_mock) -> None:
     _mock_describe(requests_mock)
     _mock_sentinel_1(requests_mock)
 
@@ -73,7 +73,7 @@ def test_query_features_reusable(requests_mock):
     assert list(query) == list(query)  # query is not exhausted after first iteration
 
 
-def test_query_features_random_access(requests_mock):
+def test_query_features_random_access(requests_mock) -> None:
     _mock_describe(requests_mock)
     _mock_sentinel_1(requests_mock)
 

--- a/tests/query/query_test.py
+++ b/tests/query/query_test.py
@@ -13,7 +13,7 @@ from cdsetool.query import (
 from datetime import date, datetime
 
 
-def test_serialize_search_term():
+def test_serialize_search_term() -> None:
     assert _serialize_search_term("foo") == "foo"
     assert _serialize_search_term(["foo", "bar"]) == "foo,bar"
     assert _serialize_search_term(date(2020, 1, 1)) == "2020-01-01"
@@ -22,7 +22,7 @@ def test_serialize_search_term():
     )
 
 
-def test_validate_search_term():
+def test_validate_search_term() -> None:
     description = {
         "productType": {"pattern": "^(S2MSI1C|S2MSI2A)$"},
         "orbitNumber": {
@@ -47,14 +47,14 @@ def test_validate_search_term():
         _validate_search_term("orbitNumber", "foobar", description)
 
 
-def test_assert_valid_key():
+def test_assert_valid_key() -> None:
     _assert_valid_key("someKey", {"someKey": True})
 
     with pytest.raises(AssertionError):
         _assert_valid_key("otherKey", {"someKey": True})
 
 
-def test_assert_match_pattern():
+def test_assert_match_pattern() -> None:
     pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(|Z|[\\+\\-][0-9]{2}:[0-9]{2}))?$"
 
     with pytest.raises(AssertionError):
@@ -79,28 +79,28 @@ def test_assert_match_pattern():
     _assert_match_pattern("descending", pattern)
 
 
-def test_assert_min_inclusive():
-    _assert_min_inclusive(1, 1)
-    _assert_min_inclusive(2, 1)
+def test_assert_min_inclusive() -> None:
+    _assert_min_inclusive("1", "1")
+    _assert_min_inclusive("2", "1")
 
     with pytest.raises(AssertionError):
-        _assert_min_inclusive(0, 1)
+        _assert_min_inclusive("0", "1")
 
 
-def test_assert_max_inclusive():
-    _assert_max_inclusive(1, 1)
-    _assert_max_inclusive(0, 1)
+def test_assert_max_inclusive() -> None:
+    _assert_max_inclusive("1", "1")
+    _assert_max_inclusive("0", "1")
 
     with pytest.raises(AssertionError):
-        _assert_max_inclusive(2, 1)
+        _assert_max_inclusive("2", "1")
 
 
-def test_shape_to_wkt():
+def test_shape_to_wkt() -> None:
     wkt = "POLYGON((10.172406299744779 55.48259118004532, 10.172406299744779 55.38234270718456, 10.42371976928382 55.38234270718456, 10.42371976928382 55.48259118004532, 10.172406299744779 55.48259118004532))"
     assert shape_to_wkt("tests/shape/POLYGON.shp") == wkt
 
 
-def test_geojson_to_wkt():
+def test_geojson_to_wkt() -> None:
     wkt = "POLYGON((10.172406299744779 55.48259118004532, 10.172406299744779 55.38234270718456, 10.42371976928382 55.38234270718456, 10.42371976928382 55.48259118004532, 10.172406299744779 55.48259118004532))"
     geojson = '{ "type": "Feature", "properties": { }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 10.172406299744779, 55.482591180045318 ], [ 10.172406299744779, 55.382342707184563 ], [ 10.423719769283821, 55.382342707184563 ], [ 10.423719769283821, 55.482591180045318 ], [ 10.172406299744779, 55.482591180045318 ] ] ] } }'
 


### PR DESCRIPTION
Add a pyright config section to pyproject.toml, type annotations to many methods/functions, and a py.typed marker so clients to the library can use the types when type checking their code.

Added some string quotes to a couple of tests to please the type checker, and changed some code to make it easier for the type checker to figure out what is going on.