### PR TITLE
download: log message on token expiry

### DIFF
--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -58,8 +58,11 @@ def download_feature(
             # Always get a new session, credentials might have expired.
             try:
                 session = _get_credentials(options).get_session()
-            except (TokenClientConnectionError, TokenExpiredSignatureError) as e:
+            except TokenClientConnectionError as e:
                 log.warning(e)
+                continue
+            except TokenExpiredSignatureError:
+                log.warning("Token signature expired, retrying..")
                 continue
             url = _follow_redirect(url, session)
             with session.get(url, stream=True) as response:


### PR DESCRIPTION
The exception does not have a message,
so the logs get an empty line with "WARNING".

Print a message instead of printing
the exception.