### PR TITLE
query: fix Python 3.12 warning

### DIFF
--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -156,7 +156,7 @@ def describe_collection(
     )
 
     parameters = {}
-    if not parameter_node_parent:
+    if parameter_node_parent is None:
         return parameters
     for parameter_node in parameter_node_parent:
         name = parameter_node.attrib.get("name")


### PR DESCRIPTION
Python 3.12 prints a deprecation
warning:

DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.

so test for None instead.