### PR TITLE
cli: add script entry point

### DIFF
--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -120,3 +120,7 @@ def _to_dict(term_list: List[str]) -> Dict[str, str]:
         key, value = item.split("=")
         search_terms[key] = value
     return search_terms
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Pylint 3.2.4 complains about
unreachable code on older Python
versions, so add the usual
entry point stuff.