### PR TITLE
credentials: retry more to login

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -147,7 +147,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
             caller=self,
             authorization=False,
             max_retries=Retry(
-                total=2,
+                total=15,
                 backoff_factor=0.5,
                 allowed_methods=None,
                 raise_on_status=False,


### PR DESCRIPTION
I initially set the retry-value
to 2 to prevent spamming bad login
credentials at the Copernicus
site, but this value is too low
when the site responds with 503.

Bump the value to 15 so people
don't get an exception thrown
in their face because of intermittent
issues with the Copernicus site.