### PR TITLE
download: log message on token connection error

### DIFF
--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -58,8 +58,8 @@ def download_feature(
             # Always get a new session, credentials might have expired.
             try:
                 session = _get_credentials(options).get_session()
-            except TokenClientConnectionError as e:
-                log.warning(e)
+            except TokenClientConnectionError:
+                log.warning("Token client connection failed, retrying..")
                 continue
             except TokenExpiredSignatureError:
                 log.warning("Token signature expired, retrying..")


### PR DESCRIPTION
The exception does not have a message,
so the logs get an empty line with "WARNING".

Print a message instead of printing
the exception.

This is a sibling to commit 7ed5b74ae3f.