### PR TITLE
gitignore: add VSCode/PyCharm dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+.vscode/


### PR DESCRIPTION
There is no IDE-configuration committed
to this repository, so ignore the directories
that IDEs use to keep track of their settings.