### PR TITLE
query_feature: retry on HTTP errors

### DIFF
--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -9,6 +9,8 @@ from xml.etree import ElementTree
 from datetime import datetime, date
 import re
 import json
+from random import random
+from time import sleep
 import geopandas as gpd
 from requests.exceptions import ChunkedEncodingError
 from urllib3.exceptions import ProtocolError
@@ -86,7 +88,12 @@ class FeatureQuery:
             attempts += 1
             try:
                 with session.get(self.next_url) as response:
-                    response.raise_for_status()
+                    if response.status_code != 200:
+                        self.log.warning(
+                            f"Status code {response.status_code}, retrying.."
+                        )
+                        sleep(60 * (1 + (random() / 4)))
+                        continue
                     res = response.json()
                     self.features += res.get("features") or []
 

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -11,6 +11,7 @@ import re
 import json
 import geopandas as gpd
 from cdsetool.credentials import Credentials
+from cdsetool.logger import NoopLogger
 
 
 class _FeatureIterator:
@@ -48,9 +49,11 @@ class FeatureQuery:
         collection: str,
         search_terms: Dict[str, Any],
         proxies: Union[Dict[str, str], None] = None,
+        options: Union[Dict[str, Any], None] = None,
     ) -> None:
         self.features = []
         self.proxies = proxies
+        self.log = (options or {}).get("logger") or NoopLogger()
         self.next_url = _query_url(
             collection, {**search_terms, "exactCount": "1"}, proxies=proxies
         )
@@ -101,11 +104,14 @@ def query_features(
     collection: str,
     search_terms: Dict[str, Any],
     proxies: Union[Dict[str, str], None] = None,
+    options: Union[Dict[str, Any], None] = None,
 ) -> FeatureQuery:
     """
     Returns an iterator over the features matching the search terms
     """
-    return FeatureQuery(collection, {"maxRecords": 2000, **search_terms}, proxies)
+    return FeatureQuery(
+        collection, {"maxRecords": 2000, **search_terms}, proxies, options
+    )
 
 
 def shape_to_wkt(shape: str) -> str:


### PR DESCRIPTION
This replicates the logic from download_feature to retry instead of crashing when there are HTTP errors and non-200 responses.