### PR TITLE
Append .zip to .SAFE instead of replacing it. Treat Sentinel 3 files accordingly

### DIFF
--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -44,7 +44,9 @@ def download_feature(
         log.debug(f"Bad URL ('{url}') or title ('{title}')")
         return None
 
-    filename = title.replace(".SAFE", ".zip")
+    filename = title.replace(".SAFE", ".SAFE.zip")
+    if title.split(".")[-1] == ".SEN3":
+        filename = title.replace(".SEN3", ".SEN3.zip")
     result_path = os.path.join(path, filename)
 
     if not options.get("overwrite_existing", False) and os.path.exists(result_path):

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -44,9 +44,7 @@ def download_feature(
         log.debug(f"Bad URL ('{url}') or title ('{title}')")
         return None
 
-    filename = title.replace(".SAFE", ".SAFE.zip")
-    if title.split(".")[-1] == ".SEN3":
-        filename = title.replace(".SEN3", ".SEN3.zip")
+    filename = title + ".zip"
     result_path = os.path.join(path, filename)
 
     if not options.get("overwrite_existing", False) and os.path.exists(result_path):


### PR DESCRIPTION
Append .zip to .SAFE (for Sentinel 1 and 2).
Include a simple if for Sentinel 3 (which has a suffix of SEN3) to append .zip there also.

Closes #180 