### PR TITLE
Use Ruff instead of black

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,16 +3,13 @@ name: Lint
 on: [push, pull_request]
 
 jobs:
-  black:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: chartboost/ruff-action@v1
         with:
-          python-version: "3.11"
-      - uses: psf/black@stable
-        with:
-          use_pyproject: true
+          args: 'format --check --diff'
 
   pylint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ dependencies = [
 ]
 [project.optional-dependencies]
 test = [
-    "black==24.8.0",
     "pylint==3.2.7",
     "pytest==8.3.2",
     "pytest-cov==5.0.0",
     "requests-mock==1.12.1",
+    "ruff==0.6.6",
     "pytest-mock==3.14.0",
 ]
 

--- a/src/cdsetool/_processing.py
+++ b/src/cdsetool/_processing.py
@@ -52,7 +52,6 @@ def _concurrent_process(
 
         # Continue until no more futures are queued
         while futures:
-
             # Wait for the first future(s) to complete
             done, not_done = wait(futures, return_when=FIRST_COMPLETED)
             futures = list(not_done)


### PR DESCRIPTION
This replaces black with Ruff.
The coding style of Ruff is based
on black so there are no significant
differences as evidenced by the size
of the diff of this PR. The main
difference is that Ruff is significantly
faster.

Ruff also provides the functionality
of isort and Flake8 with various plugins,
but this PR just replaces the formatting
parts done by black, any further linting
can be done in a future PR.