### PR TITLE
CI: use official Ruff action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v1
         with:
           args: 'format --check --diff'
 


### PR DESCRIPTION
Astral just forked the Ruff action
and state they will overhaul it,
so switch to the "official" version
of the Ruff action.