### PR TITLE
Enable Ruff "I" lint category

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           args: 'format --check --diff'
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: 'check'
 
   pylint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ max-locals = 20
 max-line-length = "88"
 disable="fixme"
 
+[tool.pylint.imports]
+disable="wrong-import-order"
+
 [tool.pyright]
 exclude = ["**/__pycache__", ".venv"]
 
@@ -60,4 +63,9 @@ executionEnvironments = [
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
+]
+
+[tool.ruff.lint]
+select = [
+    "I", # isort
 ]

--- a/src/cdsetool/_processing.py
+++ b/src/cdsetool/_processing.py
@@ -2,8 +2,7 @@
 This module provides functions for processing data concurrently
 """
 
-from concurrent.futures import Future, wait, FIRST_COMPLETED
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from typing import Callable, Generator, Iterable, List, Union
 
 from cdsetool.query import FeatureQuery

--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -2,15 +2,17 @@
 Command line interface
 """
 
+import json as JSON
 import os
 import sys
-import json as JSON
 from typing import Dict, List, Optional
-from typing_extensions import Annotated
+
 import typer
-from cdsetool.query import describe_collection, query_features
-from cdsetool.monitor import StatusMonitor
+from typing_extensions import Annotated
+
 from cdsetool.download import download_features
+from cdsetool.monitor import StatusMonitor
+from cdsetool.query import describe_collection, query_features
 
 app = typer.Typer(no_args_is_help=True)
 

--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -3,13 +3,13 @@ This module provides a class for handling credentials for
 the Copernicus Identity and Access Management (IAM) system.
 """
 
-from datetime import datetime, timedelta
 import netrc
 import threading
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Union
 
-import requests
 import jwt
+import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -7,14 +7,15 @@ all features in a result set.
 
 import os
 import random
+import shutil
 import tempfile
 import time
-import shutil
 from typing import Any, Dict, Generator, Union
 
 from requests import Session
 from requests.exceptions import ChunkedEncodingError
 from urllib3.exceptions import ProtocolError
+
 from cdsetool._processing import _concurrent_process
 from cdsetool.credentials import (
     Credentials,

--- a/src/cdsetool/monitor.py
+++ b/src/cdsetool/monitor.py
@@ -8,12 +8,12 @@ For non-interactive programs the NoopMonitor class can be used to disable
 status monitoring.
 """
 
-import time
-import threading
-import sys
 import os
-import signal
 import shutil
+import signal
+import sys
+import threading
+import time
 from typing import List, Tuple, Union
 
 IS_IPYTHON = True

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -4,16 +4,18 @@ Query the Copernicus Data Space Ecosystem OpenSearch API
 https://documentation.dataspace.copernicus.eu/APIs/OpenSearch.html
 """
 
-from typing import Any, Dict, Union
-from xml.etree import ElementTree
-from datetime import datetime, date
-import re
 import json
+import re
+from datetime import date, datetime
 from random import random
 from time import sleep
+from typing import Any, Dict, Union
+from xml.etree import ElementTree
+
 import geopandas as gpd
 from requests.exceptions import ChunkedEncodingError
 from urllib3.exceptions import ProtocolError
+
 from cdsetool.credentials import Credentials
 from cdsetool.logger import NoopLogger
 

--- a/tests/credentials/credentials_test.py
+++ b/tests/credentials/credentials_test.py
@@ -1,19 +1,20 @@
 # pyright: reportAttributeAccessIssue=false
 
+import base64
+import datetime
 import json
+
+import jwt
 import pytest
 import requests
-import datetime
-import jwt
-import base64
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
 from cdsetool.credentials import (
     Credentials,
-    NoCredentialsException,
     InvalidCredentialsException,
+    NoCredentialsException,
     TokenExchangeException,
 )
 

--- a/tests/logger/logger_test.py
+++ b/tests/logger/logger_test.py
@@ -1,8 +1,9 @@
-import pytest
 from unittest.mock import MagicMock
 
-from cdsetool.logger import NoopLogger
+import pytest
+
 from cdsetool.download import download_feature
+from cdsetool.logger import NoopLogger
 
 
 def test_noop_logger_is_default() -> None:

--- a/tests/query/query_features_test.py
+++ b/tests/query/query_features_test.py
@@ -1,4 +1,4 @@
-from cdsetool.query import query_features, FeatureQuery
+from cdsetool.query import FeatureQuery, query_features
 
 
 def _mock_describe(requests_mock):

--- a/tests/query/query_test.py
+++ b/tests/query/query_test.py
@@ -1,16 +1,17 @@
+from datetime import date, datetime
+
 import pytest
 
 from cdsetool.query import (
+    _assert_match_pattern,
+    _assert_max_inclusive,
+    _assert_min_inclusive,
+    _assert_valid_key,
     _serialize_search_term,
     _validate_search_term,
-    _assert_match_pattern,
-    _assert_valid_key,
-    _assert_min_inclusive,
-    _assert_max_inclusive,
-    shape_to_wkt,
     geojson_to_wkt,
+    shape_to_wkt,
 )
-from datetime import date, datetime
 
 
 def test_serialize_search_term() -> None:


### PR DESCRIPTION
This gives deterministic order
of imports, which increases the chance
that Github will be able to merge
independent pull requests without
manual intervention.