### PR TITLE
Add more type signatures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ exclude = ["**/__pycache__", ".venv"]
 
 # Can be strict too, see more fine-grained settings at:
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults
+# reportMissingParameterType = true
 typeCheckingMode = "standard"
 
 executionEnvironments = [

--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -32,7 +32,7 @@ class DeprecatedNoTokenException(Exception):
     """
 
 
-def NoTokenException(*args, **kwargs):  # pylint: disable=invalid-name
+def NoTokenException(*args: object, **kwargs: object):  # pylint: disable=invalid-name
     """
     Raised when no token is available
     """

--- a/src/cdsetool/logger.py
+++ b/src/cdsetool/logger.py
@@ -4,28 +4,30 @@ Logging utilities.
 This module provides a NoopLogger class that outputs nothing.
 """
 
+from typing import Any
+
 
 class NoopLogger:
     """
     A logger that does nothing.
     """
 
-    def debug(self, msg, *args, **kwargs):
+    def debug(self, msg: object, *args: Any, **kwargs: Any) -> None:
         """
         Log a debug message.
         """
 
-    def error(self, msg, *args, **kwargs):
+    def error(self, msg: object, *args: Any, **kwargs: Any) -> None:
         """
         Log an error message.
         """
 
-    def info(self, msg, *args, **kwargs):
+    def info(self, msg: object, *args: Any, **kwargs: Any) -> None:
         """
         Log an info message.
         """
 
-    def warning(self, msg, *args, **kwargs):
+    def warning(self, msg: object, *args: Any, **kwargs: Any) -> None:
         """
         Log a warning message.
         """

--- a/src/cdsetool/monitor.py
+++ b/src/cdsetool/monitor.py
@@ -61,7 +61,7 @@ class StatusMonitor(threading.Thread):
         Start the monitor
         """
 
-        def _set_line_length(_signal_num, _stack):
+        def _set_line_length(_signal_num: Union[int, None], _stack) -> None:
             self.line_length, _ = shutil.get_terminal_size()
 
         _set_line_length(None, None)
@@ -167,11 +167,11 @@ class StatusMonitor(threading.Thread):
             status.size for status in self.__done
         )
 
-    def __enter__(self):
+    def __enter__(self) -> "StatusMonitor":
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         self.stop()
 
 
@@ -186,7 +186,7 @@ class NoopMonitor:
         """
         return Status(self)
 
-    def remove_status(self, status) -> None:
+    def remove_status(self, status: "Status") -> None:
         """
         Remove a status from the monitor
         """
@@ -201,10 +201,10 @@ class NoopMonitor:
         Stop the monitor
         """
 
-    def __enter__(self):
+    def __enter__(self) -> "NoopMonitor":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         pass
 
 
@@ -257,7 +257,7 @@ class Status:
 
         return filename_line, progress_line
 
-    def add_progress(self, chunk_bytes) -> None:
+    def add_progress(self, chunk_bytes: int) -> None:
         """
         Add to the number of bytes downloaded
         """
@@ -275,13 +275,13 @@ class Status:
         """
         self.size = size
 
-    def __init__(self, monitor) -> None:
+    def __init__(self, monitor: Union[NoopMonitor, StatusMonitor]) -> None:
         self.__monitor = monitor
 
-    def __enter__(self):
+    def __enter__(self) -> "Status":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         if self.__monitor:
             self.__monitor.remove_status(self)
 

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -73,7 +73,7 @@ class FeatureQuery:
 
         return self.total_results
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         while index >= len(self.features) and self.next_url is not None:
             self.__fetch_features()
 

--- a/tests/credentials/credentials_test.py
+++ b/tests/credentials/credentials_test.py
@@ -3,6 +3,7 @@
 import base64
 import datetime
 import json
+from typing import Any
 
 import jwt
 import pytest
@@ -19,7 +20,7 @@ from cdsetool.credentials import (
 )
 
 
-def _mock_openid(requests_mock) -> None:
+def _mock_openid(requests_mock: Any) -> None:
     with open("tests/credentials/mock/openid-configuration.json") as f:
         requests_mock.get(
             "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/.well-known/openid-configuration",
@@ -27,7 +28,7 @@ def _mock_openid(requests_mock) -> None:
         )
 
 
-def _mock_token(requests_mock) -> None:
+def _mock_token(requests_mock: Any) -> None:
     headers = {"alg": "RS256", "typ": "JWT", "kid": "key-9000"}
     now = datetime.datetime.now()
     payload = {
@@ -101,7 +102,7 @@ def _mock_token(requests_mock) -> None:
     )
 
 
-def _mock_jwks(mocker) -> None:
+def _mock_jwks(mocker: Any) -> None:
     class MockResponse:
         def __init__(self, json_data) -> None:
             self.json_data = json_data
@@ -141,7 +142,7 @@ def _mock_jwks(mocker) -> None:
     mocker.patch("urllib.request.urlopen", return_value=MockResponse(jwks))
 
 
-def test_ensure_tokens(requests_mock, mocker) -> None:
+def test_ensure_tokens(requests_mock: Any, mocker: Any) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -167,7 +168,7 @@ def test_ensure_tokens(requests_mock, mocker) -> None:
     assert spy.call_count == 2
 
 
-def test_read_credentials(requests_mock, mocker) -> None:
+def test_read_credentials(requests_mock: Any, mocker: Any) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -189,7 +190,7 @@ def test_read_credentials(requests_mock, mocker) -> None:
         credentials = Credentials()
 
 
-def test_refresh_token(requests_mock, mocker) -> None:
+def test_refresh_token(requests_mock: Any, mocker: Any) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -210,7 +211,7 @@ def test_refresh_token(requests_mock, mocker) -> None:
     assert prev_access_token != credentials._Credentials__access_token
 
 
-def test_get_session(requests_mock, mocker) -> None:
+def test_get_session(requests_mock: Any, mocker: Any) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)
@@ -225,7 +226,7 @@ def test_get_session(requests_mock, mocker) -> None:
     )
 
 
-def test_token_exchange(requests_mock, mocker) -> None:
+def test_token_exchange(requests_mock: Any, mocker: Any) -> None:
     _mock_openid(requests_mock)
     _mock_token(requests_mock)
     _mock_jwks(mocker)

--- a/tests/credentials/credentials_test.py
+++ b/tests/credentials/credentials_test.py
@@ -103,16 +103,18 @@ def _mock_token(requests_mock) -> None:
 
 def _mock_jwks(mocker) -> None:
     class MockResponse:
-        def __init__(self, json_data):
+        def __init__(self, json_data) -> None:
             self.json_data = json_data
 
-        def __enter__(self):
+        def __enter__(self) -> "MockResponse":
             return self
 
-        def read(self):
+        def read(self) -> bytes:
             return json.dumps(self.json_data).encode("utf-8")
 
-        def __exit__(self, exc_type, exc_value, traceback):
+        def __exit__(
+            self, exc_type: object, exc_value: object, traceback: object
+        ) -> None:
             pass
 
     n = private_key.public_key().public_numbers().n

--- a/tests/query/query_features_test.py
+++ b/tests/query/query_features_test.py
@@ -1,7 +1,9 @@
-from cdsetool.query import FeatureQuery, query_features
+from typing import Any
+
+from cdsetool.query import query_features
 
 
-def _mock_describe(requests_mock):
+def _mock_describe(requests_mock: Any) -> None:
     url = "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel1/describe.xml"
     with open(
         "tests/query/mock/sentinel_1/describe.xml", "r", encoding="utf-8"
@@ -9,7 +11,7 @@ def _mock_describe(requests_mock):
         requests_mock.get(url, text=file.read())
 
 
-def _mock_sentinel_1(requests_mock):
+def _mock_sentinel_1(requests_mock: Any) -> None:
     urls = [
         (
             "tests/query/mock/sentinel_1/page_1.json",
@@ -38,7 +40,7 @@ def _mock_sentinel_1(requests_mock):
             requests_mock.get(url, text=file.read())
 
 
-def test_query_features_length(requests_mock) -> None:
+def test_query_features_length(requests_mock: Any) -> None:
     _mock_describe(requests_mock)
     _mock_sentinel_1(requests_mock)
 
@@ -53,7 +55,7 @@ def test_query_features_length(requests_mock) -> None:
     assert manual_count == 48
 
 
-def test_query_features_reusable(requests_mock) -> None:
+def test_query_features_reusable(requests_mock: Any) -> None:
     _mock_describe(requests_mock)
     _mock_sentinel_1(requests_mock)
 
@@ -65,7 +67,7 @@ def test_query_features_reusable(requests_mock) -> None:
     assert list(query) == list(query)  # query is not exhausted after first iteration
 
 
-def test_query_features_random_access(requests_mock) -> None:
+def test_query_features_random_access(requests_mock: Any) -> None:
     _mock_describe(requests_mock)
     _mock_sentinel_1(requests_mock)
 


### PR DESCRIPTION
Add some more type signatures on the regular code, and put in "Any" on all the mocker objects in the tests.

There are still missing type signatures in the code base, but this brings us closer to being able to enable `reportMissingParameterType` so pyright in the CI automatically enforces type signatures on new code.