### PR TITLE
Improve behavior when running under Python -O

### DIFF
--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -211,6 +211,12 @@ def _query_url(
     query_list = []
     for key, value in search_terms.items():
         val = _serialize_search_term(value)
+        if key not in description:
+            assert False, (
+                f'search_term with name "{key}" was not found for collection.'
+                + f" Available terms are: {', '.join(description.keys())}"
+            )
+            continue
         _validate_search_term(key, val, description)
         query_list.append(f"{key}={val}")
 
@@ -234,18 +240,9 @@ def _serialize_search_term(search_term: Any) -> str:
 
 
 def _validate_search_term(key: str, search_term: str, description) -> None:
-    _assert_valid_key(key, description)
     _assert_match_pattern(search_term, description.get(key).get("pattern"))
     _assert_min_inclusive(search_term, description.get(key).get("minInclusive"))
     _assert_max_inclusive(search_term, description.get(key).get("maxInclusive"))
-
-
-def _assert_valid_key(key: str, description: Dict[str, Any]) -> None:
-    assert key in description.keys(), (
-        f'search_term with name "{key}" '
-        + "was not found for collection."
-        + f" Available terms are: {', '.join(description.keys())}"
-    )
 
 
 def _assert_match_pattern(search_term: str, pattern: Union[str, None]) -> None:

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -217,8 +217,8 @@ def _query_url(
                 + f" Available terms are: {', '.join(description.keys())}"
             )
             continue
-        _validate_search_term(key, val, description)
-        query_list.append(f"{key}={val}")
+        if _valid_search_term(key, val, description):
+            query_list.append(f"{key}={val}")
 
     return (
         "https://catalogue.dataspace.copernicus.eu"
@@ -239,37 +239,46 @@ def _serialize_search_term(search_term: Any) -> str:
     return str(search_term)
 
 
-def _validate_search_term(key: str, search_term: str, description) -> None:
-    _assert_match_pattern(search_term, description.get(key).get("pattern"))
-    _assert_min_inclusive(search_term, description.get(key).get("minInclusive"))
-    _assert_max_inclusive(search_term, description.get(key).get("maxInclusive"))
+def _valid_search_term(key: str, search_term: str, description) -> bool:
+    return (
+        _valid_match_pattern(search_term, description.get(key).get("pattern"))
+        and _valid_min_inclusive(search_term, description.get(key).get("minInclusive"))
+        and _valid_max_inclusive(search_term, description.get(key).get("maxInclusive"))
+    )
 
 
-def _assert_match_pattern(search_term: str, pattern: Union[str, None]) -> None:
+def _valid_match_pattern(search_term: str, pattern: Union[str, None]) -> bool:
     if not pattern:
-        return
+        return True
 
-    assert re.match(
-        pattern, search_term
-    ), f"search_term {search_term} does not match pattern {pattern}"
+    if re.match(pattern, search_term) is None:
+        assert False, f"search_term {search_term} does not match pattern {pattern}"
+        return False
+    return True
 
 
-def _assert_min_inclusive(search_term: str, min_inclusive: Union[str, None]) -> None:
+def _valid_min_inclusive(search_term: str, min_inclusive: Union[str, None]) -> bool:
     if not min_inclusive:
-        return
+        return True
 
-    assert int(search_term) >= int(
-        min_inclusive
-    ), f"search_term {search_term} is less than min_inclusive {min_inclusive}"
+    if int(search_term) < int(min_inclusive):
+        assert (
+            False
+        ), f"search_term {search_term} is less than min_inclusive {min_inclusive}"
+        return False
+    return True
 
 
-def _assert_max_inclusive(search_term: str, max_inclusive: Union[str, None]) -> None:
+def _valid_max_inclusive(search_term: str, max_inclusive: Union[str, None]) -> bool:
     if not max_inclusive:
-        return
+        return True
 
-    assert int(search_term) <= int(
-        max_inclusive
-    ), f"search_term {search_term} is greater than max_inclusive {max_inclusive}"
+    if int(search_term) > int(max_inclusive):
+        assert (
+            False
+        ), f"search_term {search_term} is greater than max_inclusive {max_inclusive}"
+        return False
+    return True
 
 
 _describe_docs: Dict[str, bytes] = {}

--- a/tests/query/query_test.py
+++ b/tests/query/query_test.py
@@ -3,12 +3,11 @@ from datetime import date, datetime
 import pytest
 
 from cdsetool.query import (
-    _assert_match_pattern,
-    _assert_max_inclusive,
-    _assert_min_inclusive,
-    _assert_valid_key,
     _serialize_search_term,
-    _validate_search_term,
+    _valid_match_pattern,
+    _valid_max_inclusive,
+    _valid_min_inclusive,
+    _valid_search_term,
     geojson_to_wkt,
     shape_to_wkt,
 )
@@ -31,62 +30,62 @@ def test_validate_search_term() -> None:
             "pattern": "^(\\[|\\]|[0-9])?[0-9]+$|^[0-9]+?(\\[|\\])$|^(\\[|\\])[0-9]+,[0-9]+(\\[|\\])$",
         },
     }
-    _validate_search_term("productType", "S2MSI1C", description)
-    _validate_search_term("orbitNumber", "1", description)
-    _validate_search_term("orbitNumber", "43212", description)
+    assert _valid_search_term("productType", "S2MSI1C", description)
+    assert _valid_search_term("orbitNumber", "1", description)
+    assert _valid_search_term("orbitNumber", "43212", description)
 
     with pytest.raises(AssertionError):
-        _validate_search_term("productType", "foo", description)
+        _valid_search_term("productType", "foo", description)
 
     with pytest.raises(AssertionError):
-        _validate_search_term("orbitNumber", "0", description)
+        _valid_search_term("orbitNumber", "0", description)
 
     with pytest.raises(AssertionError):
-        _validate_search_term("orbitNumber", "-100", description)
+        _valid_search_term("orbitNumber", "-100", description)
 
     with pytest.raises(AssertionError):
-        _validate_search_term("orbitNumber", "foobar", description)
+        _valid_search_term("orbitNumber", "foobar", description)
 
 
 def test_assert_match_pattern() -> None:
     pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(|Z|[\\+\\-][0-9]{2}:[0-9]{2}))?$"
 
     with pytest.raises(AssertionError):
-        _assert_match_pattern("foo", pattern)
+        _valid_match_pattern("foo", pattern)
 
     with pytest.raises(AssertionError):
-        _assert_match_pattern("01-01-2020", pattern)
+        _valid_match_pattern("01-01-2020", pattern)
 
-    _assert_match_pattern("2020-01-01", None)
-    _assert_match_pattern("2020-01-01", pattern)
-    _assert_match_pattern("2020-01-01T20:31:28.888Z", pattern)
+    assert _valid_match_pattern("2020-01-01", None)
+    assert _valid_match_pattern("2020-01-01", pattern)
+    assert _valid_match_pattern("2020-01-01T20:31:28.888Z", pattern)
 
     pattern = "^(asc|desc|ascending|descending)$"
 
     with pytest.raises(AssertionError):
-        _assert_match_pattern("foo", pattern)
+        _valid_match_pattern("foo", pattern)
 
     with pytest.raises(AssertionError):
-        _assert_match_pattern("01-01-2020", pattern)
+        _valid_match_pattern("01-01-2020", pattern)
 
-    _assert_match_pattern("asc", pattern)
-    _assert_match_pattern("descending", pattern)
+    assert _valid_match_pattern("asc", pattern)
+    assert _valid_match_pattern("descending", pattern)
 
 
 def test_assert_min_inclusive() -> None:
-    _assert_min_inclusive("1", "1")
-    _assert_min_inclusive("2", "1")
+    assert _valid_min_inclusive("1", "1")
+    assert _valid_min_inclusive("2", "1")
 
     with pytest.raises(AssertionError):
-        _assert_min_inclusive("0", "1")
+        _valid_min_inclusive("0", "1")
 
 
 def test_assert_max_inclusive() -> None:
-    _assert_max_inclusive("1", "1")
-    _assert_max_inclusive("0", "1")
+    assert _valid_max_inclusive("1", "1")
+    assert _valid_max_inclusive("0", "1")
 
     with pytest.raises(AssertionError):
-        _assert_max_inclusive("2", "1")
+        _valid_max_inclusive("2", "1")
 
 
 def test_shape_to_wkt() -> None:

--- a/tests/query/query_test.py
+++ b/tests/query/query_test.py
@@ -48,13 +48,6 @@ def test_validate_search_term() -> None:
         _validate_search_term("orbitNumber", "foobar", description)
 
 
-def test_assert_valid_key() -> None:
-    _assert_valid_key("someKey", {"someKey": True})
-
-    with pytest.raises(AssertionError):
-        _assert_valid_key("otherKey", {"someKey": True})
-
-
 def test_assert_match_pattern() -> None:
     pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(|Z|[\\+\\-][0-9]{2}:[0-9]{2}))?$"
 


### PR DESCRIPTION
Move some code around so the code will work better under Python -O (where asserts are removed) when bad parameters are passed.

This will conflict with #196, I prefer to have this merged first.