### PR TITLE
Chore/update license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Styrelsen for Dataforsyning og Infrastruktur
+Copyright (c) 2024 CDSETool Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated old MIT license to reflect current circumstances, that is current year and independent CDSETool