### PR TITLE
query: retry even more

### DIFF
--- a/src/cdsetool/credentials.py
+++ b/src/cdsetool/credentials.py
@@ -73,7 +73,7 @@ class Credentials:  # pylint: disable=too-few-public-methods disable=too-many-in
     RETRY_CODES = frozenset([413, 429, 500, 502, 503])
 
     RETRIES = Retry(
-        total=5,
+        total=25,
         backoff_factor=0.5,
         raise_on_status=False,
         status_forcelist=RETRY_CODES,

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -295,16 +295,19 @@ def _get_describe_doc(
     if docs:
         return docs
     session = Credentials.make_session(None, False, Credentials.RETRIES, proxies)
-    with session.get(
-        "https://catalogue.dataspace.copernicus.eu"
-        + f"/resto/api/collections/{collection}/describe.xml",
-    ) as res:
-        assert res.status_code == 200, (
-            f"Unable to find collection with name {collection}. Please see "
-            + "https://documentation.dataspace.copernicus.eu"
-            + "/APIs/OpenSearch.html#collections "
-            + "for a list of available collections"
-        )
+    attempts = 0
+    while attempts < 10:
+        attempts += 1
+        with session.get(
+            "https://catalogue.dataspace.copernicus.eu"
+            f"/resto/api/collections/{collection}/describe.xml"
+        ) as res:
+            assert res.status_code == 200, (
+                f"Unable to find collection with name {collection}. Please see "
+                "https://documentation.dataspace.copernicus.eu"
+                "/APIs/OpenSearch.html#collections for a list of collections"
+            )
 
-        _describe_docs[collection] = res.content
-        return res.content
+            _describe_docs[collection] = res.content
+            return res.content
+    assert False, f"Failed {attempts} times to get collection {collection}, giving up."

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -302,6 +302,9 @@ def _get_describe_doc(
             "https://catalogue.dataspace.copernicus.eu"
             f"/resto/api/collections/{collection}/describe.xml"
         ) as res:
+            if res.status_code >= 500:
+                sleep(60 * (1 + (random() / 4)))
+                continue
             assert res.status_code == 200, (
                 f"Unable to find collection with name {collection}. Please see "
                 "https://documentation.dataspace.copernicus.eu"

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -227,7 +227,7 @@ def _query_url(
     )
 
 
-def _serialize_search_term(search_term: Any) -> str:
+def _serialize_search_term(search_term: object) -> str:
     if isinstance(search_term, list):
         return ",".join(search_term)
 

--- a/src/cdsetool/query.py
+++ b/src/cdsetool/query.py
@@ -211,13 +211,14 @@ def _query_url(
     query_list = []
     for key, value in search_terms.items():
         val = _serialize_search_term(value)
-        if key not in description:
+        cfg = description.get(key)
+        if cfg is None:
             assert False, (
                 f'search_term with name "{key}" was not found for collection.'
                 + f" Available terms are: {', '.join(description.keys())}"
             )
             continue
-        if _valid_search_term(key, val, description):
+        if _valid_search_term(val, cfg):
             query_list.append(f"{key}={val}")
 
     return (
@@ -239,15 +240,16 @@ def _serialize_search_term(search_term: Any) -> str:
     return str(search_term)
 
 
-def _valid_search_term(key: str, search_term: str, description) -> bool:
+def _valid_search_term(search_term: str, cfg: Dict[str, str]) -> bool:
     return (
-        _valid_match_pattern(search_term, description.get(key).get("pattern"))
-        and _valid_min_inclusive(search_term, description.get(key).get("minInclusive"))
-        and _valid_max_inclusive(search_term, description.get(key).get("maxInclusive"))
+        _valid_match_pattern(search_term, cfg)
+        and _valid_min_inclusive(search_term, cfg)
+        and _valid_max_inclusive(search_term, cfg)
     )
 
 
-def _valid_match_pattern(search_term: str, pattern: Union[str, None]) -> bool:
+def _valid_match_pattern(search_term: str, cfg: Dict[str, str]) -> bool:
+    pattern = cfg.get("pattern")
     if not pattern:
         return True
 
@@ -257,7 +259,8 @@ def _valid_match_pattern(search_term: str, pattern: Union[str, None]) -> bool:
     return True
 
 
-def _valid_min_inclusive(search_term: str, min_inclusive: Union[str, None]) -> bool:
+def _valid_min_inclusive(search_term: str, cfg: Dict[str, str]) -> bool:
+    min_inclusive = cfg.get("minInclusive")
     if not min_inclusive:
         return True
 
@@ -269,7 +272,8 @@ def _valid_min_inclusive(search_term: str, min_inclusive: Union[str, None]) -> b
     return True
 
 
-def _valid_max_inclusive(search_term: str, max_inclusive: Union[str, None]) -> bool:
+def _valid_max_inclusive(search_term: str, cfg: Dict[str, str]) -> bool:
+    max_inclusive = cfg.get("maxInclusive")
     if not max_inclusive:
         return True
 

--- a/tests/query/query_features_test.py
+++ b/tests/query/query_features_test.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import pytest
+
 from cdsetool.query import query_features
 
 
@@ -53,6 +55,20 @@ def test_query_features_length(requests_mock: Any) -> None:
         manual_count += 1
 
     assert manual_count == 48
+
+
+def test_query_features_bad_search_terms(requests_mock: Any) -> None:
+    _mock_describe(requests_mock)
+    _mock_sentinel_1(requests_mock)
+
+    with pytest.raises(AssertionError):
+        query_features("Sentinel1", {"maxRecords": 10, "bogusParam": 27})
+
+    query_features(
+        "Sentinel1",
+        {"maxRecords": 10, "bogusParam": 27},
+        options={"validate_search_terms": False},
+    )
 
 
 def test_query_features_reusable(requests_mock: Any) -> None:

--- a/tests/query/query_test.py
+++ b/tests/query/query_test.py
@@ -23,32 +23,32 @@ def test_serialize_search_term() -> None:
 
 
 def test_validate_search_term() -> None:
-    description = {
-        "productType": {"pattern": "^(S2MSI1C|S2MSI2A)$"},
-        "orbitNumber": {
-            "minInclusive": "1",
-            "pattern": "^(\\[|\\]|[0-9])?[0-9]+$|^[0-9]+?(\\[|\\])$|^(\\[|\\])[0-9]+,[0-9]+(\\[|\\])$",
-        },
+    product_type = {"pattern": "^(S2MSI1C|S2MSI2A)$"}
+    orbit_number = {
+        "minInclusive": "1",
+        "pattern": "^(\\[|\\]|[0-9])?[0-9]+$|^[0-9]+?(\\[|\\])$|^(\\[|\\])[0-9]+,[0-9]+(\\[|\\])$",
     }
-    assert _valid_search_term("productType", "S2MSI1C", description)
-    assert _valid_search_term("orbitNumber", "1", description)
-    assert _valid_search_term("orbitNumber", "43212", description)
+    assert _valid_search_term("S2MSI1C", product_type)
+    assert _valid_search_term("1", orbit_number)
+    assert _valid_search_term("43212", orbit_number)
 
     with pytest.raises(AssertionError):
-        _valid_search_term("productType", "foo", description)
+        _valid_search_term("foo", product_type)
 
     with pytest.raises(AssertionError):
-        _valid_search_term("orbitNumber", "0", description)
+        _valid_search_term("0", orbit_number)
 
     with pytest.raises(AssertionError):
-        _valid_search_term("orbitNumber", "-100", description)
+        _valid_search_term("-100", orbit_number)
 
     with pytest.raises(AssertionError):
-        _valid_search_term("orbitNumber", "foobar", description)
+        _valid_search_term("foobar", orbit_number)
 
 
 def test_assert_match_pattern() -> None:
-    pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(|Z|[\\+\\-][0-9]{2}:[0-9]{2}))?$"
+    pattern = {
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(|Z|[\\+\\-][0-9]{2}:[0-9]{2}))?$"
+    }
 
     with pytest.raises(AssertionError):
         _valid_match_pattern("foo", pattern)
@@ -56,11 +56,10 @@ def test_assert_match_pattern() -> None:
     with pytest.raises(AssertionError):
         _valid_match_pattern("01-01-2020", pattern)
 
-    assert _valid_match_pattern("2020-01-01", None)
     assert _valid_match_pattern("2020-01-01", pattern)
     assert _valid_match_pattern("2020-01-01T20:31:28.888Z", pattern)
 
-    pattern = "^(asc|desc|ascending|descending)$"
+    pattern = {"pattern": "^(asc|desc|ascending|descending)$"}
 
     with pytest.raises(AssertionError):
         _valid_match_pattern("foo", pattern)
@@ -73,19 +72,19 @@ def test_assert_match_pattern() -> None:
 
 
 def test_assert_min_inclusive() -> None:
-    assert _valid_min_inclusive("1", "1")
-    assert _valid_min_inclusive("2", "1")
+    assert _valid_min_inclusive("1", {"minInclusive": "1"})
+    assert _valid_min_inclusive("2", {"minInclusive": "1"})
 
     with pytest.raises(AssertionError):
-        _valid_min_inclusive("0", "1")
+        _valid_min_inclusive("0", {"minInclusive": "1"})
 
 
 def test_assert_max_inclusive() -> None:
-    assert _valid_max_inclusive("1", "1")
-    assert _valid_max_inclusive("0", "1")
+    assert _valid_max_inclusive("1", {"maxInclusive": "1"})
+    assert _valid_max_inclusive("0", {"maxInclusive": "1"})
 
     with pytest.raises(AssertionError):
-        _valid_max_inclusive("2", "1")
+        _valid_max_inclusive("2", {"maxInclusive": "1"})
 
 
 def test_shape_to_wkt() -> None:


### PR DESCRIPTION
The Copernicus servers give intermittent failures causing failures. Increase the number of retries in the Retry object, and add the retry+sleep-logic from download to more parts of query.

Also make a type signature more specific, and tweak the signature of "internal" parameter validation functions so they never get called with a None-parameter.

Edit: add an option to skip search term validation entirely. This eliminates those API calls to the remote server, but the remote server will obviously be unhappy if you disable search term validation and provide faulty search terms.