### PR TITLE
CI: drop permissions for workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,7 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   deploy:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pytest:
@@ -15,9 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The read contents permission is enabled
by default nowadays for repositories,
so use the empty dictionary to indicate
that.

Remove the write permissions for
the pytest workflow since I don't think
anything is currently using those.